### PR TITLE
Fix sales dynamics date comparison error

### DIFF
--- a/enhanced_dashboard.py
+++ b/enhanced_dashboard.py
@@ -191,7 +191,10 @@ def create_sales_dynamics_analysis(df, period_type='День', start_date=None, 
     
     # Фильтрация по датам если указаны
     if start_date and end_date:
-        df_filtered = df[(df['order_date'] >= start_date) & (df['order_date'] <= end_date)].copy()
+        # Преобразуем date объекты в datetime для корректного сравнения
+        start_datetime = pd.to_datetime(start_date)
+        end_datetime = pd.to_datetime(end_date) + pd.Timedelta(days=1) - pd.Timedelta(seconds=1)
+        df_filtered = df[(df['order_date'] >= start_datetime) & (df['order_date'] <= end_datetime)].copy()
     else:
         df_filtered = df.copy()
     
@@ -1723,7 +1726,7 @@ def main():
     
     # Фильтр по датам
     filtered_df = filtered_df[
-        (filtered_df['order_date'].dt.date >= start_date) & 
+        (filtered_df['order_date'].dt.date >= start_date) &
         (filtered_df['order_date'].dt.date <= end_date)
     ]
     


### PR DESCRIPTION
Fix invalid comparison between `datetime64[ns]` and `date` objects in sales dynamics analysis.

This change prevents the "Invalid comparison between dtype=datetime64[ns] and date" error when selecting custom dates for sales dynamics analysis by explicitly converting `date` objects to `datetime` for comparison.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e62432b-9f2a-4023-96bd-4e9d82efab01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e62432b-9f2a-4023-96bd-4e9d82efab01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

